### PR TITLE
fix typo in ChatMetadataAdapter

### DIFF
--- a/src/chat.php
+++ b/src/chat.php
@@ -11,7 +11,7 @@ use lightstreamer\adapters\remote\SubscriptionException;
 class ChatMetadataAdapter extends LiteralBasedProvider
 {
 
-    private $data_adaptar;
+    private $data_adapter;
 
     function __construct(ChataDataAdapter $data_adapter)
     {


### PR DESCRIPTION
there is a typo in the class property